### PR TITLE
detect failure of get_joint_info when the joint index is out of range

### DIFF
--- a/rubullet-sys/src/lib.rs
+++ b/rubullet-sys/src/lib.rs
@@ -387,7 +387,7 @@ extern "C" {
         bodyUniqueId: c_int,
         jointIndex: c_int,
         jointInfo: *mut b3JointInfo,
-    );
+    ) -> c_int;
     pub fn b3CreatePoseCommandInit(
         physClient: b3PhysicsClientHandle,
         bodyUniqueId: c_int,

--- a/rubullet/src/client.rs
+++ b/rubullet/src/client.rs
@@ -1174,7 +1174,15 @@ impl PhysicsClient {
     fn get_joint_info_intern(&mut self, body: BodyId, joint_index: usize) -> b3JointInfo {
         unsafe {
             let mut joint_info = b3JointInfo::default();
-            ffi::b3GetJointInfo(self.handle, body.0, joint_index as i32, &mut joint_info);
+            if ffi::b3GetJointInfo(self.handle, body.0, joint_index as i32, &mut joint_info) == 0 {
+                assert!(
+                    joint_index < self.get_num_joints(body),
+                    "Joint index out-of-range."
+                );
+                // This should never happen as 'b3GetJointInfo' can only fail if the joint index
+                // is out of range.
+                panic!("internal error: get_joint_info_intern failed")
+            }
             joint_info
         }
     }

--- a/rubullet/tests/tests.rs
+++ b/rubullet/tests/tests.rs
@@ -118,6 +118,19 @@ fn test_get_body_info() {
     assert_eq!(body_info.body_name.as_str(), "physics");
 }
 #[test]
+#[should_panic]
+fn test_get_joint_info_index_out_of_range() {
+    let mut physics_client = PhysicsClient::connect(Direct).unwrap();
+    physics_client
+        .set_additional_search_path("../rubullet-sys/bullet3/libbullet3/data")
+        .unwrap();
+    let r2d2 = physics_client.load_urdf("r2d2.urdf", None).unwrap();
+    let num_joints = physics_client.get_num_joints(r2d2);
+    let joint_info = physics_client.get_joint_info(r2d2, num_joints);
+    println!("{:?}", joint_info);
+}
+
+#[test]
 // tests a fixed joint and a revolute joint
 fn test_get_joint_info() {
     let mut physics_client = PhysicsClient::connect(Direct).unwrap();


### PR DESCRIPTION
Fixes #6

We now check if b3GetJointInfo was called successfully to avoid returning garbage values. The function will panic when the index is out of range 